### PR TITLE
Fix incorrect version of Github action `pypa/gh-action-pypi-publish`

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -50,4 +50,4 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@6f7e8d9c0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The example provided by Github documentation is incorrect: https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python#publishing-to-pypi
The correct version should be `pypa/gh-action-pypi-publish@release/v1`