### PR TITLE
Fix incorrect warped image size

### DIFF
--- a/wpodnet/backend.py
+++ b/wpodnet/backend.py
@@ -55,12 +55,16 @@ class Prediction:
         drawer = ImageDraw.Draw(canvas)
         drawer.polygon(self.bounds, fill=fill, outline=outline, width=width)
 
-    def warp(self, canvas: Image.Image) -> Image.Image:  # pragma: no cover
+    def warp(
+        self, canvas: Image.Image, width: int = 208, height: int = 60
+    ) -> Image.Image:  # pragma: no cover
         """
         Warps the image with perspective based on the bounding polygon.
 
         Args:
             canvas (PIL.Image.Image): The image to be warped.
+            width (int): The width of the output warped image. Defaults to 208.
+            height (int): The height of the output warped image. Defaults to 60.
 
         Returns:
             PIL.Image.Image: The warped image.
@@ -69,14 +73,12 @@ class Prediction:
             startpoints=self.bounds,
             endpoints=[
                 (0, 0),
-                (canvas.width, 0),
-                (canvas.width, canvas.height),
-                (0, canvas.height),
+                (width, 0),
+                (width, height),
+                (0, height),
             ],
         )
-        return canvas.transform(
-            (canvas.width, canvas.height), Image.Transform.PERSPECTIVE, coeffs
-        )
+        return canvas.transform((width, height), Image.Transform.PERSPECTIVE, coeffs)
 
 
 Q = np.array(

--- a/wpodnet/backend.py
+++ b/wpodnet/backend.py
@@ -56,15 +56,15 @@ class Prediction:
         drawer.polygon(self.bounds, fill=fill, outline=outline, width=width)
 
     def warp(
-        self, canvas: Image.Image, width: int = 208, height: int = 60
+        self, canvas: Image.Image, width: int = 240, height: int = 80
     ) -> Image.Image:  # pragma: no cover
         """
         Warps the image with perspective based on the bounding polygon.
 
         Args:
             canvas (PIL.Image.Image): The image to be warped.
-            width (int): The width of the output warped image. Defaults to 208.
-            height (int): The height of the output warped image. Defaults to 60.
+            width (int): The width of the output warped image. Defaults to 240.
+            height (int): The height of the output warped image. Defaults to 80.
 
         Returns:
             PIL.Image.Image: The warped image.


### PR DESCRIPTION
The warped image size should be fixed by default _(208, 60)_: https://github.com/sergiomsilva/alpr-unconstrained/blob/master/license-plate-detection.py#L46